### PR TITLE
fix/ small produt card tags position fixed

### DIFF
--- a/public/css/components/product-card.css
+++ b/public/css/components/product-card.css
@@ -141,6 +141,10 @@
     --fs-subtext: 0.7rem;
 }
 
+[data-product-card='small'] .product_card_price_tag {
+    flex-grow: 1;
+}
+
 [data-product-card='small'] .product_card_description {
     display: none;
 }


### PR DESCRIPTION
Tags were not showing properly at the bottom of the small product card. Fixed by adding flex grow to the price element